### PR TITLE
feat: dark techno theme with scroll animations

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,13 +32,18 @@ fetch('events.json')
 const themeToggle = document.getElementById('theme-toggle');
 const body = document.body;
 const setTheme = (dark) => {
-  dark ? body.classList.add('dark') : body.classList.remove('dark');
-  themeToggle.textContent = dark ? '☀️' : '🌙';
+  if (dark) {
+    body.classList.remove('light');
+    themeToggle.textContent = '☀️';
+  } else {
+    body.classList.add('light');
+    themeToggle.textContent = '🌙';
+  }
 };
-setTheme(localStorage.getItem('theme') === 'dark');
+setTheme(localStorage.getItem('theme') !== 'light');
 
 themeToggle.addEventListener('click', () => {
-  const dark = !body.classList.contains('dark');
+  const dark = body.classList.contains('light');
   setTheme(dark);
   localStorage.setItem('theme', dark ? 'dark' : 'light');
 });
@@ -61,3 +66,15 @@ form.addEventListener('submit', (e) => {
 
 // set current year
 document.getElementById('year').textContent = new Date().getFullYear();
+
+// scroll reveal
+const observer = new IntersectionObserver((entries, obs) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('show');
+      obs.unobserve(entry.target);
+    }
+  });
+});
+
+document.querySelectorAll('.reveal').forEach((el) => observer.observe(el));

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <a href="#djs">DJs</a>
       <a href="#events">Events</a>
       <a href="#contact">Contact</a>
-      <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+      <button id="theme-toggle" aria-label="Toggle theme">☀️</button>
     </nav>
     <button id="menu-toggle" aria-label="Toggle menu" class="hamburger">☰</button>
   </header>
@@ -24,17 +24,17 @@
     <h2 id="hero-text">Feel the bass</h2>
   </section>
 
-  <section id="about" class="section">
+  <section id="about" class="section reveal">
     <h2>About Terra Kontra</h2>
     <p>Terra Kontra is a collective of boundary pushing DJs and artists determined to shake the planet with underground sound. From warehouse raves to sun‑rise beach sets, we exist to amplify community, culture and raw energy.</p>
   </section>
 
-  <section id="festival" class="section alt">
+  <section id="festival" class="section alt reveal">
     <h2>Terra Kontra Festival</h2>
     <p>Every summer we host our own festival where the lineup is curated by the crew and the crowd. Expect 48 hours of non‑stop music, art installations and that indescribable TK vibe.</p>
   </section>
 
-  <section id="djs" class="section">
+  <section id="djs" class="section reveal">
     <h2>The Crew</h2>
     <ul class="dj-list">
       <li>Astra</li>
@@ -45,12 +45,12 @@
     </ul>
   </section>
 
-  <section id="events" class="section alt">
+  <section id="events" class="section alt reveal">
     <h2>Upcoming Events</h2>
     <div id="event-list" class="events">Loading events...</div>
   </section>
 
-  <section id="contact" class="section">
+  <section id="contact" class="section reveal">
     <h2>Join the Movement</h2>
     <form id="subscribe-form" class="subscribe">
       <input type="email" placeholder="Your email" required />

--- a/style.css
+++ b/style.css
@@ -1,12 +1,14 @@
 :root {
-  --bg: #ffffff;
-  --text: #111111;
-  --accent: #ff0055;
+  --bg: #000000;
+  --text: #f5f5f5;
+  --accent: #ff0033;
+  --alt-bg: #111111;
 }
 
-body.dark {
-  --bg: #111111;
-  --text: #f9f9f9;
+body.light {
+  --bg: #ffffff;
+  --text: #111111;
+  --alt-bg: #f2f2f2;
 }
 
 body {
@@ -26,7 +28,7 @@ body {
   top: 0;
   background: var(--bg);
   z-index: 100;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(255,0,51,0.2);
 }
 
 .logo {
@@ -38,6 +40,10 @@ body {
   margin: 0 1rem;
   text-decoration: none;
   color: var(--text);
+}
+
+.nav a:hover {
+  color: var(--accent);
 }
 
 #theme-toggle {
@@ -80,8 +86,8 @@ body {
   align-items: center;
   justify-content: center;
   height: 60vh;
-  background: linear-gradient(135deg, #ff0055, #ff5500);
-  color: #ffffff;
+  background: linear-gradient(135deg, #000000, #330000);
+  color: var(--accent);
   text-align: center;
 }
 
@@ -90,7 +96,18 @@ body {
 }
 
 .section.alt {
-  background: #f2f2f2;
+  background: var(--alt-bg);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .dj-list {
@@ -109,13 +126,21 @@ body {
 }
 
 .events .event {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--accent);
   padding: 1rem 0;
 }
 
 .subscribe input {
   padding: 0.5rem;
   margin-right: 0.5rem;
+}
+
+.subscribe button {
+  background: var(--accent);
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- switch site to a black and red techno-inspired theme
- add scroll-triggered reveal animations for content sections
- default to dark mode with a light-mode toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60a4a792c832ea55c58917f1647d6